### PR TITLE
Fix provisioning for modern Dataplicity API, Python 3.14, reverse-proxy hack

### DIFF
--- a/custom_components/dataplicity/__init__.py
+++ b/custom_components/dataplicity/__init__.py
@@ -24,8 +24,10 @@ async def async_setup(hass: HomeAssistant, hass_config: dict):
     try:
         package.install_package = fake_install
 
+        # 0.5.13 verified working; older versions had a redirect_port bug
         await async_process_requirements(hass, DOMAIN, ["dataplicity==0.5.13"])
 
+        # fix Python 3.11+ support (getargspec removed in 3.11)
         if not hasattr(inspect, "getargspec"):
             def getargspec(*args):
                 spec = inspect.getfullargspec(*args)
@@ -41,11 +43,13 @@ async def async_setup(hass: HomeAssistant, hass_config: dict):
         package.install_package = real_install
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    # fix https://github.com/AlexxIT/Dataplicity/issues/29
     try:
         Client = await hass.async_add_executor_job(utils.import_client)
         hass.data[DOMAIN] = client = Client(
             serial=entry.data["serial"], auth_token=entry.data["auth"]
         )
+        # replace default 80 port to Hass port (usual 8123)
         client.port_forward.add_service("web", hass.config.api.port)
         Thread(name=DOMAIN, target=client.run_forever).start()
         async def hass_stop(event):

--- a/custom_components/dataplicity/__init__.py
+++ b/custom_components/dataplicity/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 from threading import Thread
 
 from homeassistant.config_entries import ConfigEntry
@@ -10,60 +11,55 @@ from homeassistant.util import package
 from . import utils
 
 DOMAIN = "dataplicity"
-
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, hass_config: dict):
     real_install = package.install_package
 
     def fake_install(pkg: str, *args, **kwargs):
-        if pkg == "dataplicity==0.4.40":
+        if pkg == "dataplicity==0.5.13":
             return utils.install_package(pkg, *args, **kwargs)
         return real_install(pkg, *args, **kwargs)
 
     try:
         package.install_package = fake_install
 
-        # latest dataplicity has bug with redirect_port
-        await async_process_requirements(hass, DOMAIN, ["dataplicity==0.4.40"])
+        await async_process_requirements(hass, DOMAIN, ["dataplicity==0.5.13"])
 
-        # fix Python 3.11 support
         if not hasattr(inspect, "getargspec"):
-
             def getargspec(*args):
                 spec = inspect.getfullargspec(*args)
                 return spec.args, spec.varargs, spec.varkw, spec.defaults
-
             inspect.getargspec = getargspec
 
         return True
-    except:
+    except Exception:
+        import traceback
+        _LOGGER.error("Dataplicity setup failed:\n%s", traceback.format_exc())
         return False
     finally:
         package.install_package = real_install
 
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
-    # fix https://github.com/AlexxIT/Dataplicity/issues/29
-    Client = await hass.async_add_executor_job(utils.import_client)
-
-    hass.data[DOMAIN] = client = Client(
-        serial=entry.data["serial"], auth_token=entry.data["auth"]
-    )
-    # replace default 80 port to Hass port (usual 8123)
-    client.port_forward.add_service("web", hass.config.api.port)
-    Thread(name=DOMAIN, target=client.run_forever).start()
-
-    async def hass_stop(event):
-        client.exit()
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, hass_stop)
-
-    await utils.fix_middleware(hass)
-
-    return True
-
+    try:
+        Client = await hass.async_add_executor_job(utils.import_client)
+        hass.data[DOMAIN] = client = Client(
+            serial=entry.data["serial"], auth_token=entry.data["auth"]
+        )
+        client.port_forward.add_service("web", hass.config.api.port)
+        Thread(name=DOMAIN, target=client.run_forever).start()
+        async def hass_stop(event):
+            client.exit()
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, hass_stop)
+        await utils.fix_middleware(hass)
+        return True
+    except Exception:
+        import traceback
+        _LOGGER.error("async_setup_entry failed:\n%s", traceback.format_exc())
+        return False
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    client = hass.data[DOMAIN]
-    client.exit()
+    client = hass.data.pop(DOMAIN, None)
+    if client is not None:
+        client.exit()
     return True

--- a/custom_components/dataplicity/config_flow.py
+++ b/custom_components/dataplicity/config_flow.py
@@ -10,7 +10,13 @@ from . import DOMAIN, utils
 
 _LOGGER = logging.getLogger(__name__)
 
-RE_TOKEN = re.compile(r"https://www\.dataplicity\.com/([a-z0-9-]+)\.py")
+RE_INSTALL_URL = re.compile(
+    r"https?://(?:www\.)?dataplicity\.com/([A-Za-z0-9_\-]+)\.(?:py|sh)"
+)
+
+RE_TOKEN_CHARS = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+RE_RECOVERY = re.compile(r"^([A-Za-z0-9_\-]{8,}):(.+)$")
 
 
 class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -32,21 +38,45 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors={"base": error} if error else None,
             )
 
-        m = RE_TOKEN.search(data["token"])
-        token = m[1] if m else data["token"]
-        # fix new format `https://www.dataplicity.com/3-********.py`
-        token = re.sub(r"^\d-", "", token)
+        input_str = data["token"].strip()
 
-        if not token.isalnum():
-            return await self.async_step_user(error="token")
+        if not input_str.lower().startswith("http"):
+            m_rec = RE_RECOVERY.match(input_str)
+            if m_rec:
+                serial, auth = m_rec.group(1), m_rec.group(2).strip()
+                return self.async_create_entry(
+                    title="Dataplicity",
+                    data={"auth": auth, "serial": serial},
+                    description_placeholders={"device_url": ""},
+                )
+
+            m = RE_INSTALL_URL.search(input_str)
+            token = m.group(1) if m else input_str
+            token = re.sub(r"^\d-", "", token)
+
+            if not token.isalnum():
+                if not RE_TOKEN_CHARS.match(token):
+                    return await self.async_step_user(error="token")
+        else:
+            m = RE_INSTALL_URL.search(input_str)
+            token = m.group(1) if m else input_str
+            token = re.sub(r"^\d-", "", token)
+
+            if not RE_TOKEN_CHARS.match(token):
+                return await self.async_step_user(error="token")
 
         session = async_get_clientsession(self.hass)
-        resp = await utils.register_device(session, token)
+
+        device_class_hash = await utils.fetch_device_class_hash(session, token)
+        if device_class_hash is None:
+            return await self.async_step_user(error="token")
+
+        resp = await utils.register_device(session, token, device_class_hash)
         if resp:
             return self.async_create_entry(
                 title="Dataplicity",
                 data={"auth": resp["auth"], "serial": resp["serial"]},
-                description_placeholders={"device_url": resp["device_url"]},
+                description_placeholders={"device_url": resp.get("device_url", "")},
             )
 
         return await self.async_step_user(error="auth")

--- a/custom_components/dataplicity/manifest.json
+++ b/custom_components/dataplicity/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/AlexxIT/Dataplicity/issues",
   "requirements": [],
-  "version": "1.2.2"
+  "version": "1.3.0"
 }

--- a/custom_components/dataplicity/translations/en.json
+++ b/custom_components/dataplicity/translations/en.json
@@ -14,9 +14,9 @@
     "step": {
       "user": {
         "title": "Register Dataplicity Device",
-        "description": "Sign up to [Dataplicity](https://www.dataplicity.com/) and paste full install line or URL or Token:\n`https://www.dataplicity.com/XXXXXXXX.py`",
+        "description": "Sign up to [Dataplicity](https://www.dataplicity.com/) and paste the install URL from Add device:\n`https://dataplicity.com/XXXXXXXX.sh`\n\nOr, to reuse already-provisioned credentials, paste them as `serial:auth`.",
         "data": {
-          "token": "URL or Token"
+          "token": "Install URL or serial:auth"
         }
       }
     }

--- a/custom_components/dataplicity/translations/ru.json
+++ b/custom_components/dataplicity/translations/ru.json
@@ -1,22 +1,22 @@
 {
   "config": {
     "create_entry": {
-      "default": "Home Assistant \u0434\u043e\u0431\u0430\u0432\u043b\u0435\u043d \u0432 Dataplicity. \u0412\u043a\u043b\u044e\u0447\u0438\u0442\u0435 **Wormhole** \u0432 [\u043d\u0430\u0441\u0442\u0440\u043e\u0439\u043a\u0430\u0445 \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u0430]({device_url}) \u0434\u043b\u044f \u043f\u0443\u0431\u043b\u0438\u0447\u043d\u043e\u0433\u043e HTTPS \u0434\u043e\u0441\u0442\u0443\u043f\u0430."
+      "default": "Home Assistant добавлен в Dataplicity. Включите **Wormhole** в [настройках устройства]({device_url}) для публичного HTTPS доступа."
     },
     "abort": {
-      "win32": "Windows \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044f",
-      "ssl": "[SSL \u043a\u043e\u043d\u0444\u0438\u0433](https://www.home-assistant.io/integrations/http/) \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044f"
+      "win32": "Windows не поддерживается",
+      "ssl": "[SSL конфиг](https://www.home-assistant.io/integrations/http/) не поддерживается"
     },
     "error": {
-      "auth": "\u041e\u0448\u0438\u0431\u043a\u0430 \u043f\u0440\u0438 \u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u0438 \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u0430",
-      "token": "\u041d\u0435\u0432\u0435\u0440\u043d\u044b\u0439 URL \u0438\u043b\u0438 \u0442\u043e\u043a\u0435\u043d"
+      "auth": "Ошибка при регистрации устройства",
+      "token": "Неверный URL или токен"
     },
     "step": {
       "user": {
-        "title": "\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u044f \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u0430 Dataplicity",
-        "description": "\u0417\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u0443\u0439\u0442\u0435\u0441\u044c \u0432 \u0441\u0435\u0440\u0432\u0438\u0441\u0435 [Dataplicity](https://www.dataplicity.com/) \u0438 \u0432\u0441\u0442\u0430\u0432\u044c\u0442\u0435 \u0441\u0441\u044b\u043b\u043a\u0443 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438 \u0438\u0437 \u043a\u043d\u043e\u043f\u043a\u0438 Add device:\n`https://dataplicity.com/XXXXXXXX.sh`\n\n\u0418\u043b\u0438, \u0447\u0442\u043e\u0431\u044b \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c \u0443\u0436\u0435 \u043f\u043e\u043b\u0443\u0447\u0435\u043d\u043d\u044b\u0435 \u0443\u0447\u0451\u0442\u043d\u044b\u0435 \u0434\u0430\u043d\u043d\u044b\u0435, \u0432\u0441\u0442\u0430\u0432\u044c\u0442\u0435 \u0438\u0445 \u0432 \u0444\u043e\u0440\u043c\u0430\u0442\u0435 `serial:auth`.",
+        "title": "Регистрация устройства Dataplicity",
+        "description": "Зарегистрируйтесь в сервисе [Dataplicity](https://www.dataplicity.com/) и вставьте ссылку установки из кнопки Add device:\n`https://dataplicity.com/XXXXXXXX.sh`\n\nИли, чтобы использовать уже полученные учётные данные, вставьте их в формате `serial:auth`.",
         "data": {
-          "token": "\u0421\u0441\u044b\u043b\u043a\u0430 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438 \u0438\u043b\u0438 serial:auth"
+          "token": "Ссылка установки или serial:auth"
         }
       }
     }

--- a/custom_components/dataplicity/translations/ru.json
+++ b/custom_components/dataplicity/translations/ru.json
@@ -1,22 +1,22 @@
 {
   "config": {
     "create_entry": {
-      "default": "Home Assistant добавлен в сервис Dataplicity. Включите **Wormhole** в [настройках устройства]({device_url}) для публичного HTTPS доступа."
+      "default": "Home Assistant \u0434\u043e\u0431\u0430\u0432\u043b\u0435\u043d \u0432 Dataplicity. \u0412\u043a\u043b\u044e\u0447\u0438\u0442\u0435 **Wormhole** \u0432 [\u043d\u0430\u0441\u0442\u0440\u043e\u0439\u043a\u0430\u0445 \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u0430]({device_url}) \u0434\u043b\u044f \u043f\u0443\u0431\u043b\u0438\u0447\u043d\u043e\u0433\u043e HTTPS \u0434\u043e\u0441\u0442\u0443\u043f\u0430."
     },
     "abort": {
-      "win32": "Windows не поддерживается",
-      "ssl": "[SSL конфигурация](https://www.home-assistant.io/integrations/http/) не поддерживается"
+      "win32": "Windows \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044f",
+      "ssl": "[SSL \u043a\u043e\u043d\u0444\u0438\u0433](https://www.home-assistant.io/integrations/http/) \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044f"
     },
     "error": {
-      "auth": "Ошибка в процессе регистрации устройства",
-      "token": "Неправильная ссылка или токен"
+      "auth": "\u041e\u0448\u0438\u0431\u043a\u0430 \u043f\u0440\u0438 \u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u0438 \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u0430",
+      "token": "\u041d\u0435\u0432\u0435\u0440\u043d\u044b\u0439 URL \u0438\u043b\u0438 \u0442\u043e\u043a\u0435\u043d"
     },
     "step": {
       "user": {
-        "title": "Регистрация устройства Dataplicity",
-        "description": "Зарегистрируйтесь в сервисе [Dataplicity](https://www.dataplicity.com/) и вставьте полную строку установки или ссылку или токен:\n`https://www.dataplicity.com/XXXXXXXX.py`",
+        "title": "\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u044f \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u0430 Dataplicity",
+        "description": "\u0417\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u0443\u0439\u0442\u0435\u0441\u044c \u0432 \u0441\u0435\u0440\u0432\u0438\u0441\u0435 [Dataplicity](https://www.dataplicity.com/) \u0438 \u0432\u0441\u0442\u0430\u0432\u044c\u0442\u0435 \u0441\u0441\u044b\u043b\u043a\u0443 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438 \u0438\u0437 \u043a\u043d\u043e\u043f\u043a\u0438 Add device:\n`https://dataplicity.com/XXXXXXXX.sh`\n\n\u0418\u043b\u0438, \u0447\u0442\u043e\u0431\u044b \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c \u0443\u0436\u0435 \u043f\u043e\u043b\u0443\u0447\u0435\u043d\u043d\u044b\u0435 \u0443\u0447\u0451\u0442\u043d\u044b\u0435 \u0434\u0430\u043d\u043d\u044b\u0435, \u0432\u0441\u0442\u0430\u0432\u044c\u0442\u0435 \u0438\u0445 \u0432 \u0444\u043e\u0440\u043c\u0430\u0442\u0435 `serial:auth`.",
         "data": {
-          "token": "Ссылка или токен"
+          "token": "\u0421\u0441\u044b\u043b\u043a\u0430 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438 \u0438\u043b\u0438 serial:auth"
         }
       }
     }

--- a/custom_components/dataplicity/utils.py
+++ b/custom_components/dataplicity/utils.py
@@ -19,6 +19,8 @@ def install_package(
     timeout: int | None = None,
 ) -> bool:
     """Install dataplicity package via pip subprocess (avoids recursion with fake_install)."""
+    # important to use --no-deps, because some transitive packages
+    # (e.g. lomond) have versions that conflict with Home Assistant constraints
     args = [
         sys.executable,
         "-m",
@@ -48,7 +50,7 @@ def install_package(
         stdout=PIPE,
         stderr=PIPE,
         env=env,
-        close_fds=False,
+        close_fds=False,  # required for posix_spawn
     ) as process:
         _, stderr = process.communicate()
         if process.returncode != 0:
@@ -109,10 +111,21 @@ async def register_device(session: ClientSession, token: str, device_class_hash:
 
 
 async def fix_middleware(hass: HomeAssistant):
-    """Silent hack to allow Dataplicity wormhole (reverse proxy from 127.0.0.1)."""
+    """Dirty hack for HTTP integration. Plug and play for usual users...
+
+    [v2021.7] Home Assistant will now block HTTP requests when a misconfigured
+    reverse proxy, or misconfigured Home Assistant instance when using a
+    reverse proxy, has been detected.
+
+    http:
+      use_x_forwarded_for: true
+      trusted_proxies:
+      - 127.0.0.1
+    """
     for f in hass.http.app.middlewares:
         if getattr(f, "__name__", None) != "forwarded_middleware":
             continue
+        #  https://til.hashrocket.com/posts/ykhyhplxjh-examining-the-closure
         for i, var in enumerate(f.__code__.co_freevars):
             cell = f.__closure__[i]
             if var == "use_x_forwarded_for":
@@ -125,6 +138,7 @@ async def fix_middleware(hass: HomeAssistant):
 
 
 def import_client():
+    # fix: type object 'array.array' has no attribute 'tostring'
     try:
         from dataplicity import iptool
     except ImportError:
@@ -132,6 +146,7 @@ def import_client():
     else:
         iptool.get_all_interfaces = lambda: [("lo", "127.0.0.1")]
 
+    # fix: module 'platform' has no attribute 'linux_distribution'
     try:
         from dataplicity import device_meta
     except ImportError:

--- a/custom_components/dataplicity/utils.py
+++ b/custom_components/dataplicity/utils.py
@@ -1,54 +1,14 @@
 import logging
 import os
+import re
 import sys
-from ipaddress import IPv4Network
 from subprocess import Popen, PIPE
 
 from aiohttp import ClientSession
 from homeassistant.core import HomeAssistant
+from ipaddress import IPv4Network
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def register_device(session: ClientSession, token: str):
-    try:
-        r = await session.post(
-            "https://www.dataplicity.com/install/",
-            data={"name": "Home Assistant", "serial": "None", "token": token},
-        )
-        if r.status != 200:
-            _LOGGER.error(f"Can't register dataplicity device: {r.status}")
-            return None
-        return await r.json()
-    except:
-        _LOGGER.exception("Can't register dataplicity device")
-        return None
-
-
-async def fix_middleware(hass: HomeAssistant):
-    """Dirty hack for HTTP integration. Plug and play for usual users...
-
-    [v2021.7] Home Assistant will now block HTTP requests when a misconfigured
-    reverse proxy, or misconfigured Home Assistant instance when using a
-    reverse proxy, has been detected.
-
-    http:
-      use_x_forwarded_for: true
-      trusted_proxies:
-      - 127.0.0.1
-    """
-    for f in hass.http.app.middlewares:
-        if f.__name__ != "forwarded_middleware":
-            continue
-        #  https://til.hashrocket.com/posts/ykhyhplxjh-examining-the-closure
-        for i, var in enumerate(f.__code__.co_freevars):
-            cell = f.__closure__[i]
-            if var == "use_x_forwarded_for":
-                if not cell.cell_contents:
-                    cell.cell_contents = True
-            elif var == "trusted_proxies":
-                if not cell.cell_contents:
-                    cell.cell_contents = [IPv4Network("127.0.0.1/32")]
 
 
 def install_package(
@@ -58,9 +18,7 @@ def install_package(
     constraints: str | None = None,
     timeout: int | None = None,
 ) -> bool:
-    # important to use no-deps, because:
-    # - enum34 has problems with Hass constraints
-    # - six has problmes with Python 3.12
+    """Install dataplicity package via pip subprocess (avoids recursion with fake_install)."""
     args = [
         sys.executable,
         "-m",
@@ -69,12 +27,9 @@ def install_package(
         "--quiet",
         package,
         "--no-deps",
-        # "enum34==1.1.6",
-        # "six==1.10.0",
         "lomond==0.3.3",
     ]
     env = os.environ.copy()
-
     if timeout:
         args += ["--timeout", str(timeout)]
     if upgrade:
@@ -93,7 +48,7 @@ def install_package(
         stdout=PIPE,
         stderr=PIPE,
         env=env,
-        close_fds=False,  # required for posix_spawn
+        close_fds=False,
     ) as process:
         _, stderr = process.communicate()
         if process.returncode != 0:
@@ -103,20 +58,86 @@ def install_package(
                 stderr.decode("utf-8").lstrip().strip(),
             )
             return False
-
     return True
+
+PROVISION_URL = "https://app-api.dataplicity.com/device-gateway/provision/"
+SH_URL_TEMPLATE = "https://dataplicity.com/{token}.sh"
+RE_DEVICE_CLASS_HASH = re.compile(r"device_class_hash=([a-f0-9]{64})")
+
+
+async def fetch_device_class_hash(session: ClientSession, token: str):
+    try:
+        r = await session.get(SH_URL_TEMPLATE.format(token=token))
+        if r.status != 200:
+            _LOGGER.error(f"Can't fetch install wrapper for token: {r.status}")
+            return None
+        text = await r.text()
+        m = RE_DEVICE_CLASS_HASH.search(text)
+        if not m:
+            _LOGGER.error("device_class_hash not found in install wrapper")
+            return None
+        return m.group(1)
+    except Exception:
+        _LOGGER.exception("Can't fetch device_class_hash")
+        return None
+
+
+async def register_device(session: ClientSession, token: str, device_class_hash: str):
+    try:
+        r = await session.post(
+            PROVISION_URL,
+            data={
+                "provisioning_key": token,
+                "name": "Home Assistant",
+                "device_class_hash": device_class_hash,
+            },
+            headers={"User-Agent": "Python-urllib/3.11"},
+        )
+        if r.status != 200:
+            _LOGGER.error(f"Can't register dataplicity device: {r.status}")
+            return None
+        body = await r.json()
+        serial = body.get("hash_id") or body.get("serial")
+        auth = body.get("device_secret") or body.get("auth")
+        if not serial or not auth:
+            _LOGGER.error(f"Provisioning response missing creds: keys={list(body)}")
+            return None
+        return {"serial": serial, "auth": auth, "device_url": body.get("device_url", "")}
+    except Exception:
+        _LOGGER.exception("Can't register dataplicity device")
+        return None
+
+
+async def fix_middleware(hass: HomeAssistant):
+    """Silent hack to allow Dataplicity wormhole (reverse proxy from 127.0.0.1)."""
+    for f in hass.http.app.middlewares:
+        if getattr(f, "__name__", None) != "forwarded_middleware":
+            continue
+        for i, var in enumerate(f.__code__.co_freevars):
+            cell = f.__closure__[i]
+            if var == "use_x_forwarded_for":
+                if not cell.cell_contents:
+                    cell.cell_contents = True
+            elif var == "trusted_proxies":
+                if not cell.cell_contents:
+                    cell.cell_contents = [IPv4Network("127.0.0.1/32")]
+        break
 
 
 def import_client():
-    # fix: type object 'array.array' has no attribute 'tostring'
-    from dataplicity import iptool
+    try:
+        from dataplicity import iptool
+    except ImportError:
+        pass
+    else:
+        iptool.get_all_interfaces = lambda: [("lo", "127.0.0.1")]
 
-    iptool.get_all_interfaces = lambda: [("lo", "127.0.0.1")]
-
-    # fix: module 'platform' has no attribute 'linux_distribution'
-    from dataplicity import device_meta
-
-    device_meta.get_os_version = lambda: "Linux"
+    try:
+        from dataplicity import device_meta
+    except ImportError:
+        pass
+    else:
+        device_meta.get_os_version = lambda: "Linux"
 
     from dataplicity.client import Client
 


### PR DESCRIPTION
## Summary

This PR supersedes #50 by fixing the Dataplicity integration for modern infrastructure **without** breaking the existing silent reverse-proxy hack.

### Background

PR #50 (petrouv) correctly updated the provisioning logic for the new Dataplicity API (`.sh` URLs, `device_class_hash`, new response fields). However, it introduced several regressions that break the integration on current Home Assistant / Python 3.14:

1. **Broken `fix_middleware`** — #50 replaced the working closure-cell hack with a `co_freevars` assignment that crashes on Python 3.14 (`tuple` is immutable). This silently disables the reverse-proxy auto-configuration, causing the wormhole to return **400 Bad Request** unless the user manually edits `configuration.yaml`.
2. **Missing `utils.install_package`** — #50 deleted the `install_package` helper but `__init__.py` still calls it inside `fake_install`, leading to an unlogged `AttributeError` / recursion crash during setup.
3. **No exception logging** — the bare `except:` in `async_setup` swallows all errors, making failures invisible.
4. **Missing `hass.data` cleanup** — `async_unload_entry` kept a reference to the dead client.

### What this PR does differently

- **Provisioning**: same modern API fix as #50 (new endpoint, `.sh` support, `device_class_hash`, `hash_id`/`device_secret` fallbacks, `serial:auth` recovery mode).
- **`fix_middleware`**: **restores the original cell-contents hack** that worked for years, plus `getattr(f, "__name__", None)` safety. No `co_freevars` mutation.
- **`install_package`**: kept and documented with `--no-deps` reasoning.
- **Error handling**: `async_setup` and `async_setup_entry` now log full tracebacks.
- **Cleanup**: `async_unload_entry` pops `hass.data[DOMAIN]`.
- **Agent**: bumped to `dataplicity==0.5.13` (verified end-to-end; the `redirect_port` bug that pinned `0.4.40` is gone).

### Tested on
- Home Assistant Container 2026.5.2
- Python 3.14
- Dataplicity agent 0.5.13

### Closes
- #49
- #47
- #48
